### PR TITLE
Handle invalid result from quantize palette call

### DIFF
--- a/lib/palette.js
+++ b/lib/palette.js
@@ -48,5 +48,8 @@ function palette(canvas, n) {
     arr.push([data[i], data[i + 1], data[i + 2]]);
   }
 
-  return quantize(arr, n).palette();
+  var colorMap = quantize(arr, n);
+  if (!colorMap) { return []; }
+
+  return colorMap.palette();
 }


### PR DESCRIPTION
Sometimes, the `palette` from the `CMap` of quantize can return `false`, leading to an uncaught error. This helps catching it smoothly by returning an empty array.